### PR TITLE
ACC-1169 main branch name change chores

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,15 +3,15 @@
 ---
 references:
 
-  container_config_node8: &container_config_node8
+  container_config_node: &container_config_node
     working_directory: ~/project/build
     docker:
-      - image: circleci/node:8-browsers
+      - image: circleci/node:12-browsers
 
-  container_config_lambda_node8: &container_config_lambda_node8
+  container_config_lambda_node: &container_config_lambda_node
     working_directory: ~/project/build
     docker:
-      - image: lambci/lambda:build-nodejs8.10
+      - image: lambci/lambda:build-nodejs12.x
 
   workspace_root: &workspace_root
     ~/project
@@ -60,7 +60,7 @@ version: 2
 jobs:
 
   build:
-    <<: *container_config_node8
+    <<: *container_config_node
     steps:
       - checkout
       - run:
@@ -93,7 +93,7 @@ jobs:
             - build
 
   test:
-    <<: *container_config_node8
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - run:
@@ -113,7 +113,7 @@ jobs:
           destination: test-results
 
   publish:
-    <<: *container_config_node8
+    <<: *container_config_node
     steps:
       - *attach_workspace
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,13 +36,13 @@ references:
     restore_cache:
       <<: *npm_cache_keys
 
-  filters_only_master: &filters_only_master
+  filters_only_main: &filters_only_main
     branches:
-      only: master
+      only: main
 
-  filters_ignore_master: &filters_ignore_master
+  filters_ignore_main: &filters_ignore_main
     branches:
-      ignore: master
+      ignore: main
 
   filters_ignore_tags: &filters_ignore_tags
     tags:
@@ -158,7 +158,7 @@ workflows:
       - schedule:
           cron: "0 0 * * *"
           filters:
-            <<: *filters_only_master
+            <<: *filters_only_main
     jobs:
       - build:
           context: next-nightly-build

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ a configurable [express](https://github.com/expressjs/express) decorator to auto
 
 [![npm version](https://badge.fury.io/js/%40financial-times%2Fn-express-monitor.svg)](https://badge.fury.io/js/%40financial-times%2Fn-express-monitor)
 [![CircleCI](https://circleci.com/gh/Financial-Times/n-express-monitor.svg?style=shield)](https://circleci.com/gh/Financial-Times/n-express-monitor)
-[![Coverage Status](https://coveralls.io/repos/github/Financial-Times/n-express-monitor/badge.svg?branch=master)](https://coveralls.io/github/Financial-Times/n-express-monitor?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/Financial-Times/n-express-monitor/badge.svg?branch=main)](https://coveralls.io/github/Financial-Times/n-express-monitor?branch=main)
 [![gitter chat](https://badges.gitter.im/Financial-Times/n-express-monitor.svg)](https://gitter.im/Financial-Times/n-express-monitor?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2FFinancial-Times%2Fn-express-monitor.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2FFinancial-Times%2Fn-express-monitor?ref=badge_shield)
 
 ![node version](https://img.shields.io/node/v/@financial-times/n-express-monitor.svg)
 [![Known Vulnerabilities](https://snyk.io/test/github/Financial-Times/n-express-monitor/badge.svg)](https://snyk.io/test/github/Financial-Times/n-express-monitor)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Financial-Times/n-express-monitor/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/Financial-Times/n-express-monitor/?branch=master)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Financial-Times/n-express-monitor/badges/quality-score.png?b=main)](https://scrutinizer-ci.com/g/Financial-Times/n-express-monitor/?branch=main)
 [![Dependencies](https://david-dm.org/Financial-Times/n-express-monitor.svg)](https://david-dm.org/Financial-Times/n-express-monitor)
 [![devDependencies](https://david-dm.org/Financial-Times/n-express-monitor/dev-status.svg)](https://david-dm.org/Financial-Times/n-express-monitor?type=dev)
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "supertest": "^3.3.0"
   },
   "engines": {
-    "node": ">=6.1.0"
+    "node": "12.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,9 +10,6 @@
     "test": "jest",
     "cover": "jest --coverage",
     "prepublish": "make build",
-    "precommit": "node_modules/.bin/secret-squirrel",
-    "commitmsg": "node_modules/.bin/secret-squirrel-commitmsg",
-    "prepush": "make lint unit-test && make verify -j3",
     "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "dependencies": {
@@ -20,7 +17,7 @@
     "@financial-times/n-auto-metrics": "^4.0.0-beta.2"
   },
   "devDependencies": {
-    "@financial-times/n-gage": "^3.6.0",
+    "@financial-times/n-gage": "^8.2.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^10.0.0",
@@ -42,5 +39,12 @@
   },
   "engines": {
     "node": "12.x"
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "node_modules/.bin/secret-squirrel-commitmsg",
+      "pre-commit": "node_modules/.bin/secret-squirrel",
+      "pre-push": "make lint unit-test && make verify -j3"
+    }
   }
 }


### PR DESCRIPTION
**Description**
Following the branch name change, this PR handles associated chores as per https://github.com/Financial-Times/next/wiki/Migrating-apps-to-use-main-branch-(instead-of-master)
- upgrades n-gage
- updates CI yaml to use the new name
- updates links
- bumps up node version in package.json to 12
- bumps up node version in CI docker images to 12
- closes #12 

**Ticket**
https://financialtimes.atlassian.net/browse/ACC-1169

**We're bumping how many n-gage versions?!**
TOO MANY. But I think none of those changes affect this repo.
v8.0.0 - the package-lock.json change is opt in https://github.com/Financial-Times/n-gage/releases/tag/v8.0.0
v7.0.0 - is an upgrade to Node v12 https://github.com/Financial-Times/n-gage/releases/tag/v7.0.0
v6.0.0 - something to do with asset-hashes.json, action only needed if this file is present in the project
v5.0.0 - updates Husky format. Staging smoke tests now run on https
v4.0.0 - removes all n-ui related code